### PR TITLE
Enable using synapseClient and rGithubClient

### DIFF
--- a/mPower-summaries.R
+++ b/mPower-summaries.R
@@ -1,3 +1,10 @@
+## The packages synapseClient and rGithubClient are not in standard CRAN,
+## so get them from synapse and github.
+source("http://depot.sagebase.org/CRAN.R")
+pkgInstall("synapseClient")
+install.packages("devtools")
+devtools::install_github("brian-bot/rGithubClient")
+
 require(synapseClient)
 require(rGithubClient)
 require(ggplot2)


### PR DESCRIPTION
2 packages are not in CRAN, so enable retrieving them from non-standard locations.
